### PR TITLE
Run without API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Derived from `wa.sh` by [saironiq](https://github.com/saironiq/shellscripts/tree
 
 ## How To Use
 
+You should get your own [API Key](https://developer.wolframalpha.com/portal/apisignup.html) (called AppID on WolframAlpha) from WolframAlpha before use. It can take a few minutes or hours to get your API key once you apply for it. If you do not provide an API key then a fallback will be used, however that may result in a few missing / incorrect characters in the output.
+
 Simply type the query as you would at [WolframAlpha.com](https://wolframalpha.com), examples:
 
     tungsten "P=NP"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Derived from `wa.sh` by [saironiq](https://github.com/saironiq/shellscripts/tree
 
 ## How To Use
 
-You must get your own [API Key](https://developer.wolframalpha.com/portal/apisignup.html) (called AppID on WolframAlpha) from WolframAlpha before use. It can take a few minutes or hours to get your API key once you apply for it.
-
 Simply type the query as you would at [WolframAlpha.com](https://wolframalpha.com), examples:
 
     tungsten "P=NP"


### PR DESCRIPTION
I've managed to find a way to run without an API key by sending the request as if you're coming from https://products.wolframalpha.com/api/explorer/.

There's an extra dependency on `iconv`, however (on Arch at least) it's part of the `glibc` package so no extra installation is required